### PR TITLE
Fix sticker-convert version issue

### DIFF
--- a/bucket/sticker-convert.json
+++ b/bucket/sticker-convert.json
@@ -1,6 +1,6 @@
 {
-    "##": "Sticker-convert",
-    "version": "2.11.1",
+    "##": "Sticker-convert. If this 2.11.2, check out bucket/issues/3.",
+    "version": "2.11.2",
     "description": "Convert (animated) stickers to/from WhatsApp, Telegram, Signal, Line, Kakao, Viber, iMessage.",
     "homepage": "https://github.com/laggykiller/sticker-convert",
     "license": "GPL-2.0-or-later",


### PR DESCRIPTION
Update the version in the sticker-convert configuration (sloply) to address the current broken state. 

There's no changes in windows in this new version

Fixes #3