### PR TITLE
Force pwsh in a new way, excavator now uses notPlancha/scoop

### DIFF
--- a/.github/workflows/excavator.yml
+++ b/.github/workflows/excavator.yml
@@ -16,3 +16,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SKIP_UPDATED: '0'
           THROW_ERROR: '1'
+          FORCE_PWSH: '1'


### PR DESCRIPTION
https://github.com/ScoopInstaller/GithubActions/pull/48 was introduced, so this applies it instead of relying on an old https://github.com/notPlancha/Scoop-GitHub-Actions version. 

Additionally, https://github.com/ScoopInstaller/GithubActions/commit/09d1a04ca768216af00a846bcb8f6cae1745c1cd was introduced, which means that the exacator should now in theory use my fork, which Fixes #2.